### PR TITLE
Adding singleUseTokenId in PurchaseRequest

### DIFF
--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -152,4 +152,24 @@ class Gateway extends AbstractGateway
         return $this->createRequest('\Omnipay\PaywayRest\Message\TransactionDetailRequest', $parameters);
 
     }
+
+    /**
+     * Get List of Merchants
+     * @param array $parameters
+     * @return \Omnipay\PaywayRest\Message\MerchantListRequest
+     */
+    public function getMerchants(array $parameters = array())
+    {
+        return $this->createRequest('\Omnipay\PaywayRest\Message\MerchantListRequest', $parameters);
+    }
+
+    /**
+     * Get List of Bank Accounts
+     * @param array $parameters
+     * @return \Omnipay\PaywayRest\Message\BankAccountListRequest
+     */
+    public function getBankAccounts(array $parameters = array())
+    {
+        return $this->createRequest('\Omnipay\PaywayRest\Message\BankAccountListRequest', $parameters);
+    }
 }

--- a/src/Message/BankAccountListRequest.php
+++ b/src/Message/BankAccountListRequest.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * PaywayRest Transaction Detail Request
+ */
+namespace Omnipay\PaywayRest\Message;
+
+/**
+ * PaywayRest Bank Account List Request
+ *
+ * @link https://www.payway.com.au/docs/rest.html#your-bank-accounts
+ */
+class BankAccountListRequest extends AbstractRequest
+{
+    public function getData()
+    {
+        return $data = array();
+    }
+
+    public function getEndpoint()
+    {
+        return $this->endpoint . '/your-bank-accounts';
+    }
+
+    public function getHttpMethod()
+    {
+        return 'GET';
+    }
+
+    public function getUseSecretKey()
+    {
+        return true;
+    }
+}

--- a/src/Message/MerchantListRequest.php
+++ b/src/Message/MerchantListRequest.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * PaywayRest Transaction Detail Request
+ */
+namespace Omnipay\PaywayRest\Message;
+
+/**
+ * PaywayRest Merchant ListRequest
+ *
+ * @link https://www.payway.com.au/docs/rest.html#list-merchants
+ */
+class MerchantListRequest extends AbstractRequest
+{
+    public function getData()
+    {
+        return $data = array();
+    }
+
+    public function getEndpoint()
+    {
+        return $this->endpoint . '/merchants';
+    }
+
+    public function getHttpMethod()
+    {
+        return 'GET';
+    }
+
+    public function getUseSecretKey()
+    {
+        return true;
+    }
+}


### PR DESCRIPTION
As per the trusted frame documentation, It is possible for us to make a payment transaction without creating new customer.
https://www.payway.com.au/docs/rest.html#transactions

This is possible if we send singleUseTokenId in data array
Message/PurchaseRequest.php  line number 40

if($this->getSingleUseTokenId()){
$data['singleUseTokenId'] = $this->getSingleUseTokenId();
}